### PR TITLE
Chainable api support

### DIFF
--- a/example.js
+++ b/example.js
@@ -15,13 +15,13 @@ const schema = {
   }
 }
 
-fastify.get('/', schema, function (req, reply) {
-  reply(null, { hello: 'world' })
-})
-
-fastify.post('/', schema, function (req, reply) {
-  reply(null, { hello: 'world' })
-})
+fastify
+  .get('/', schema, function (req, reply) {
+    reply(null, { hello: 'world' })
+  })
+  .post('/', schema, function (req, reply) {
+    reply(null, { hello: 'world' })
+  })
 
 server.listen(8000, function (err) {
   if (err) {

--- a/fastify.js
+++ b/fastify.js
@@ -59,6 +59,7 @@ function build () {
       node[opts.method] = opts
       map.set(opts.url, node)
     }
+    return fastify
   }
 
   function bodyParsed (handle, params, req, res) {

--- a/test/chainable.js
+++ b/test/chainable.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const fastify = require('..')()
+
+const noop = () => {}
+const schema = {
+  out: {
+    type: 'object',
+    properties: {
+      hello: {
+        type: 'string'
+      }
+    }
+  }
+}
+
+test('chainable - get', t => {
+  t.plan(1)
+  t.type(fastify.get('/', schema, noop), fastify)
+})
+
+test('chainable - post', t => {
+  t.plan(1)
+  t.type(fastify.post('/', schema, noop), fastify)
+})
+
+test('chainable - route', t => {
+  t.plan(1)
+  t.type(fastify.route({
+    method: 'GET',
+    url: '/other',
+    schema: schema,
+    handler: noop
+  }), fastify)
+})


### PR DESCRIPTION
As titled.
```javascript
fastify
  .get('/', schema, function (req, reply) {
    reply(null, { hello: 'world' })
  })
  .post('/', schema, function (req, reply) {
    reply(null, { hello: 'world' })
  })
```