### PR TITLE
Split logic

### DIFF
--- a/fastify.js
+++ b/fastify.js
@@ -7,6 +7,9 @@ const jsonParser = require('body/json')
 
 const supportedMethods = ['GET', 'POST', 'PUT']
 const validation = require('./lib/validation')
+const buildSchema = validation.buildSchema
+const validateSchema = validation.validateSchema
+const serialize = validation.serialize
 
 function build () {
   const router = wayfarer('/404')
@@ -55,7 +58,7 @@ function build () {
       throw new Error(`Missing handler function for ${opts.method}:${opts.url} route.`)
     }
 
-    validation.buildSchema(opts)
+    buildSchema(opts)
 
     if (map.has(opts.url)) {
       if (map.get(opts.url)[opts.method]) {
@@ -113,7 +116,7 @@ function build () {
       res.end()
     }
 
-    const valid = validation.validateSchema(handle, params, body, query)
+    const valid = validateSchema(handle, params, body, query)
     if (valid !== true) {
       res.statusCode = 400
       res.end(valid)
@@ -135,7 +138,7 @@ function build () {
       }
 
       res.statusCode = statusCode
-      res.end(handle[validation.outputSchema](data))
+      res.end(serialize(handle, data))
     }
   }
 

--- a/fastify.js
+++ b/fastify.js
@@ -3,21 +3,10 @@
 const wayfarer = require('wayfarer')
 const urlUtil = require('url')
 const stripUrl = require('pathname-match')
-const fastJsonStringify = require('fast-json-stringify')
-const fastSafeStringify = require('fast-safe-stringify')
-const Ajv = require('ajv')
 const jsonParser = require('body/json')
 
 const supportedMethods = ['GET', 'POST', 'PUT']
-const ajv = new Ajv({ coerceTypes: true })
-
-const payloadSchema = Symbol('payload-schema')
-const querystringSchema = Symbol('querystring-schema')
-const outputSchema = Symbol('output-schema')
-const paramsSchema = Symbol('params-scehma')
-
-const schemas = require('./lib/schemas.json')
-const inputSchemaError = fastJsonStringify(schemas.inputSchemaError)
+const validation = require('./lib/validation')
 
 function build () {
   const router = wayfarer('/404')
@@ -66,23 +55,7 @@ function build () {
       throw new Error(`Missing handler function for ${opts.method}:${opts.url} route.`)
     }
 
-    if (opts.schema && opts.schema.out) {
-      opts[outputSchema] = fastJsonStringify(opts.schema.out)
-    } else {
-      opts[outputSchema] = fastSafeStringify
-    }
-
-    if (opts.schema && opts.schema.payload) {
-      opts[payloadSchema] = ajv.compile(opts.schema.payload)
-    }
-
-    if (opts.schema && opts.schema.querystring) {
-      opts[querystringSchema] = ajv.compile(opts.schema.querystring)
-    }
-
-    if (opts.schema && opts.schema.params) {
-      opts[paramsSchema] = ajv.compile(opts.schema.params)
-    }
+    validation.buildSchema(opts)
 
     if (map.has(opts.url)) {
       if (map.get(opts.url)[opts.method]) {
@@ -140,21 +113,10 @@ function build () {
       res.end()
     }
 
-    if (handle[paramsSchema] && !handle[paramsSchema](params)) {
+    const valid = validation.validateSchema(handle, params, body, query)
+    if (valid !== true) {
       res.statusCode = 400
-      res.end(inputSchemaError(handle[paramsSchema].errors))
-      return
-    }
-
-    if (handle[payloadSchema] && !handle[payloadSchema](body)) {
-      res.statusCode = 400
-      res.end(inputSchemaError(handle[payloadSchema].errors))
-      return
-    }
-
-    if (handle[querystringSchema] && !handle[querystringSchema](query)) {
-      res.statusCode = 400
-      res.end(inputSchemaError(handle[querystringSchema].errors))
+      res.end(valid)
       return
     }
 
@@ -173,7 +135,7 @@ function build () {
       }
 
       res.statusCode = statusCode
-      res.end(handle[outputSchema](data))
+      res.end(handle[validation.outputSchema](data))
     }
   }
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -53,4 +53,8 @@ function validateSchema (handle, params, body, query) {
   return true
 }
 
-module.exports = { buildSchema, validateSchema, outputSchema }
+function serialize (handle, data) {
+  return handle[outputSchema](data)
+}
+
+module.exports = { buildSchema, validateSchema, serialize }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,0 +1,56 @@
+'use strict'
+
+const fastJsonStringify = require('fast-json-stringify')
+const fastSafeStringify = require('fast-safe-stringify')
+const Ajv = require('ajv')
+const ajv = new Ajv({ coerceTypes: true })
+
+const payloadSchema = Symbol('payload-schema')
+const querystringSchema = Symbol('querystring-schema')
+const outputSchema = Symbol('output-schema')
+const paramsSchema = Symbol('params-scehma')
+
+const schemas = require('./schemas.json')
+const inputSchemaError = fastJsonStringify(schemas.inputSchemaError)
+
+function buildSchema (opts) {
+  if (!opts.schema) {
+    opts[outputSchema] = fastSafeStringify
+    return
+  }
+
+  if (opts.schema.out) {
+    opts[outputSchema] = fastJsonStringify(opts.schema.out)
+  } else {
+    opts[outputSchema] = fastSafeStringify
+  }
+
+  if (opts.schema.payload) {
+    opts[payloadSchema] = ajv.compile(opts.schema.payload)
+  }
+
+  if (opts.schema.querystring) {
+    opts[querystringSchema] = ajv.compile(opts.schema.querystring)
+  }
+
+  if (opts.schema.params) {
+    opts[paramsSchema] = ajv.compile(opts.schema.params)
+  }
+}
+
+function validateSchema (handle, params, body, query) {
+  if (handle[paramsSchema] && !handle[paramsSchema](params)) {
+    return inputSchemaError(handle[paramsSchema].errors)
+  }
+
+  if (handle[payloadSchema] && !handle[payloadSchema](body)) {
+    return inputSchemaError(handle[payloadSchema].errors)
+  }
+
+  if (handle[querystringSchema] && !handle[querystringSchema](query)) {
+    return inputSchemaError(handle[querystringSchema].errors)
+  }
+  return true
+}
+
+module.exports = { buildSchema, validateSchema, outputSchema }


### PR DESCRIPTION
In this first commit I've moved the `schema validation` in its own file.
I think we could split also `route` handling, `createNode` and `hanldeNode` in their own file.

Its ok for you? Any suggestion?