### PR TITLE
Logger support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ contribute!
 * [Usage](#usage)
 * [Benchmarks](#benchmarks)
 * [API](#api)
+* [Logging](#logging)
 * [Team](#team)
 * [Acknowledgements](#acknowledgements)
 * [License](#license)
@@ -262,6 +263,25 @@ module.exports = function (fastify, options, next) {
   })
   next()
 }
+```
+
+<a name="logging"></a>
+## Logging
+Since Fastify is really focused on performances, we choose the best logger to achieve the goal. **[Pino](https://github.com/pinojs/pino)**!  
+By default Fastify uses [pino-http](https://github.com/pinojs/pino-http) as logger, with the log level setted to `'fatal'`.
+
+If you want to pass some options to the logger, just pass the logger option to fastify.
+You can find all the options [here](https://github.com/pinojs/pino#pinoopts-stream). If you want to pass a custom stream to the Pino instance, just add the stream field to the logger object.
+```js
+const split = require('split2')
+const stream = split(JSON.parse)
+
+const fastify = require('fastify')({
+  logger: {
+    level: 'info',
+    stream: stream
+  }
+})
 ```
 
 <a name="team"></a>

--- a/fastify.js
+++ b/fastify.js
@@ -16,9 +16,11 @@ function build (options) {
   if (typeof options !== 'object') {
     throw new TypeError('Options must be an object')
   }
-  if (options.logger === true) options.logger = {}
 
+  options.logger = options.logger || {}
+  options.logger.level = options.logger.level || 'fatal'
   const logger = pinoHttp(options.logger)
+
   const router = wayfarer('/404')
   const map = new Map()
   pluginLoader(fastify, {})
@@ -50,9 +52,7 @@ function build (options) {
   return fastify
 
   function fastify (req, res) {
-    if (options.logger) {
-      logger(req, res)
-    }
+    logger(req, res)
     router(stripUrl(req.url), req, res)
   }
 

--- a/fastify.js
+++ b/fastify.js
@@ -5,6 +5,7 @@ const stripUrl = require('pathname-match')
 const pluginLoader = require('boot-in-the-arse')
 const http = require('http')
 const https = require('https')
+const pinoHttp = require('pino-http')
 
 const supportedMethods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS']
 const buildSchema = require('./lib/validation').build
@@ -15,7 +16,9 @@ function build (options) {
   if (typeof options !== 'object') {
     throw new TypeError('Options must be an object')
   }
+  if (options.logger === true) options.logger = {}
 
+  const logger = pinoHttp(options.logger)
   const router = wayfarer('/404')
   const map = new Map()
   pluginLoader(fastify, {})
@@ -47,6 +50,9 @@ function build (options) {
   return fastify
 
   function fastify (req, res) {
+    if (options.logger) {
+      logger(req, res)
+    }
     router(stripUrl(req.url), req, res)
   }
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "pre-commit": "^1.1.3",
     "request": "^2.79.0",
     "snazzy": "^5.0.0",
+    "split2": "^2.1.0",
     "standard": "^8.6.0",
     "take-five": "^1.3.0",
     "tap": "^8.0.1"
@@ -45,7 +46,7 @@
     "fast-json-stringify": "^0.10.1",
     "fast-safe-stringify": "^1.1.3",
     "pathname-match": "^1.2.0",
-    "pino-http": "^2.0.1",
+    "pino-http": "^2.1.0",
     "wayfarer": "^6.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,24 +27,25 @@
   },
   "homepage": "https://github.com/mcollina/fastify#readme",
   "devDependencies": {
-    "coveralls": "^2.11.14",
+    "coveralls": "^2.11.15",
     "express": "^4.14.0",
     "hapi": "^15.2.0",
     "koa": "^1.2.4",
     "pre-commit": "^1.1.3",
-    "request": "^2.76.0",
+    "request": "^2.79.0",
     "snazzy": "^5.0.0",
-    "standard": "^8.5.0",
+    "standard": "^8.6.0",
     "take-five": "^1.3.0",
-    "tap": "^8.0.0"
+    "tap": "^8.0.1"
   },
   "dependencies": {
-    "ajv": "^4.8.2",
+    "ajv": "^4.9.0",
     "body": "^5.1.0",
     "boot-in-the-arse": "^0.3.0",
-    "fast-json-stringify": "^0.10.0",
-    "fast-safe-stringify": "^1.1.1",
+    "fast-json-stringify": "^0.10.1",
+    "fast-safe-stringify": "^1.1.3",
     "pathname-match": "^1.2.0",
-    "wayfarer": "^6.2.1"
+    "pino-http": "^2.0.1",
+    "wayfarer": "^6.3.0"
   }
 }

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const request = require('request')
+const Fastify = require('..')
+var fastify = null
+
+try {
+  fastify = Fastify({ logger: true })
+  t.pass()
+} catch (e) {
+  t.fail()
+}
+
+fastify.get('/', function (req, reply) {
+  try {
+    req.req.log.info('test')
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+  reply(null, 200, { hello: 'world' })
+})
+
+fastify.listen(3000, err => {
+  t.error(err)
+
+  fastify.server.unref()
+
+  test('should log the request', t => {
+    t.plan(3)
+    request({
+      method: 'GET',
+      uri: 'http://localhost:' + fastify.server.address().port,
+      json: {}
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.deepEqual(body, { hello: 'world' })
+    })
+  })
+})


### PR DESCRIPTION
As titled, related to #8.

By default the logger is not enabled, if the user passes `{ logger: true }` or `{ logger: options }` it will be enabled for all the request.

If everything is ok for you, I can update the docs.
I've also updated the dependencies.