### PR TITLE
Reply refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ profile-*
 
 # webstorm
 .idea
+
+# flamegraphs
+profile*

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,5 @@ node_js:
   - "6"
   - "5"
   - "4"
-# after_script:
-#   - npm run coveralls
-
+after_script:
+  - npm run coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ node_js:
   - "6"
   - "5"
   - "4"
-after_script:
-  - npm run coveralls
+# after_script:
+#   - npm run coveralls
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,31 @@ fastify.route({
 })
 ```
 
+The handler can also return a Promise, and it supports async/await:
+
+```js
+fastify.route({
+  method: 'GET',
+  url: '/',
+  schema: {
+    out: {
+      type: 'object',
+      properties: {
+        hello: {
+          type: 'string'
+        }
+      }
+    }
+  },
+  handler: async function (request) {
+    var res = await new Promise(function (resolve) {
+      setTimeout(resolve, 200, { hello: 'world' })
+    })
+    return res
+  }
+})
+```
+
 <a name="request"></a>
 #### Request
 

--- a/examples/example.js
+++ b/examples/example.js
@@ -15,7 +15,7 @@ const schema = {
 
 fastify
   .get('/', schema, function (req, reply) {
-    reply.header('Content-Type', 'text/plain').code(200)
+    reply.header('Content-Type', 'application/json').code(200)
     reply.send({ hello: 'world' })
   })
   .post('/', schema, function (req, reply) {

--- a/examples/example.js
+++ b/examples/example.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const fastify = require('../fastify')()
+const Promise = require('bluebird')
 
 const schema = {
   out: {
@@ -15,8 +16,15 @@ const schema = {
 
 fastify
   .get('/', schema, function (req, reply) {
-    reply.header('Content-Type', 'application/json').code(200)
-    reply.send({ hello: 'world' })
+    // reply.header('Content-Type', 'application/json').code(200)
+    // reply.send({ hello: 'world' })
+    reply.header('content-type', 'text/plain').code(200).send('callback!')
+  })
+  .get('/promise', function (req, reply) {
+    const promise = new Promise(function (resolve, reject) {
+      resolve('promise!')
+    })
+    reply.header('content-type', 'text/plain').code(200).send(promise)
   })
   .post('/', schema, function (req, reply) {
     reply.send(null, { hello: 'world' })

--- a/examples/example.js
+++ b/examples/example.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const fastify = require('../fastify')()
-const Promise = require('bluebird')
 
 const schema = {
   out: {

--- a/examples/example.js
+++ b/examples/example.js
@@ -15,20 +15,20 @@ const schema = {
 
 fastify
   .get('/', schema, function (req, reply) {
-    reply.header('Content-Type', 'application-json').code(200)
-    reply.reply(null, { hello: 'world' })
+    reply.header('Content-Type', 'text/plain').code(200)
+    reply.send({ hello: 'world' })
   })
   .post('/', schema, function (req, reply) {
-    reply(null, { hello: 'world' })
+    reply.send(null, { hello: 'world' })
   })
   .head('/', {}, function (req, reply) {
-    reply(null)
+    reply.send(null)
   })
   .delete('/', schema, function (req, reply) {
-    reply(null, { hello: 'world' })
+    reply.send(null, { hello: 'world' })
   })
   .patch('/', schema, function (req, reply) {
-    reply(null, { hello: 'world' })
+    reply.send(null, { hello: 'world' })
   })
 
 fastify.listen(3000, err => {

--- a/examples/example.js
+++ b/examples/example.js
@@ -25,6 +25,11 @@ fastify
     })
     reply.header('content-type', 'application/json').code(200).send(promise)
   })
+  .get('/stream', function (req, reply) {
+    const fs = require('fs')
+    const stream = fs.createReadStream(process.cwd() + '/examples/plugin.js', 'utf8')
+    reply.code(200).send(stream)
+  })
   .post('/', schema, function (req, reply) {
     reply.send(null, { hello: 'world' })
   })

--- a/examples/example.js
+++ b/examples/example.js
@@ -15,7 +15,8 @@ const schema = {
 
 fastify
   .get('/', schema, function (req, reply) {
-    reply(null, { hello: 'world' })
+    reply.header('Content-Type', 'application-json').code(200)
+    reply.reply(null, { hello: 'world' })
   })
   .post('/', schema, function (req, reply) {
     reply(null, { hello: 'world' })

--- a/examples/example.js
+++ b/examples/example.js
@@ -24,6 +24,12 @@ fastify
     })
     reply.header('content-type', 'application/json').code(200).send(promise)
   })
+  .get('/return-promise', schema, function (req, reply) {
+    const promise = new Promise(function (resolve, reject) {
+      resolve({ hello: 'world' })
+    })
+    return promise
+  })
   .get('/stream', function (req, reply) {
     const fs = require('fs')
     const stream = fs.createReadStream(process.cwd() + '/examples/plugin.js', 'utf8')

--- a/examples/example.js
+++ b/examples/example.js
@@ -16,15 +16,14 @@ const schema = {
 
 fastify
   .get('/', schema, function (req, reply) {
-    // reply.header('Content-Type', 'application/json').code(200)
-    // reply.send({ hello: 'world' })
-    reply.header('content-type', 'text/plain').code(200).send('callback!')
+    reply.header('Content-Type', 'application/json').code(200)
+    reply.send({ hello: 'world' })
   })
-  .get('/promise', function (req, reply) {
+  .get('/promise', schema, function (req, reply) {
     const promise = new Promise(function (resolve, reject) {
-      resolve('promise!')
+      resolve({ hello: 'world' })
     })
-    reply.header('content-type', 'text/plain').code(200).send(promise)
+    reply.header('content-type', 'application/json').code(200).send(promise)
   })
   .post('/', schema, function (req, reply) {
     reply.send(null, { hello: 'world' })

--- a/examples/plugin.js
+++ b/examples/plugin.js
@@ -3,10 +3,10 @@
 module.exports = function (fastify, opts, next) {
   fastify
     .get('/', opts.schema, function (req, reply) {
-      reply(null, { hello: 'world' })
+      reply.send({ hello: 'world' })
     })
     .post('/', opts.schema, function (req, reply) {
-      reply(null, { hello: 'world' })
+      reply.send({ hello: 'world' })
     })
   next()
 }

--- a/lib/tier-node.js
+++ b/lib/tier-node.js
@@ -84,23 +84,47 @@ function handler (handle, params, req, res, body, query) {
   }
 
   const request = new Request(params, req, body, query)
-  handle.handler(request, reply)
+  handle.handler(request, new Reply(res, handle))
+}
 
-  function reply (err, statusCode, data) {
-    if (err) {
-      res.statusCode = 500
-      res.end()
-      return
-    }
+function Reply (res, handle) {
+  this.res = res
+  this.handle = handle
+}
 
-    if (!data) {
-      data = statusCode
-      statusCode = 200
-    }
-
-    res.statusCode = statusCode
-    res.end(serialize(handle, data))
+Reply.prototype.reply = function (err, statusCode, data) {
+  if (err) {
+    this.res.statusCode = 500
+    this.res.end()
+    return
   }
+
+  if (!data) {
+    data = statusCode
+    statusCode = 200
+  }
+
+  const str = serialize(this.handle, data)
+  this.res.setHeader('Content-Length', Buffer.byteLength(str))
+
+  if (!this.res.getHeader('Content-Type')) {
+    this.res.setHeader('Content-Type', 'application/json')
+  }
+  if (!this.res.statusCode) {
+    this.res.statusCode = statusCode
+  }
+
+  this.res.end(str)
+}
+
+Reply.prototype.header = function (key, value) {
+  this.res.setHeader(key, value)
+  return this
+}
+
+Reply.prototype.code = function (code) {
+  this.res.statusCode = code
+  return this
 }
 
 function Request (params, req, body, query) {

--- a/lib/tier-node.js
+++ b/lib/tier-node.js
@@ -1,5 +1,13 @@
 'use strict'
 
+/**
+ * Instead of using directly res.end(), we are using setImmediate(…)
+ * This because we have observed that with this technique we are faster at responding to the various requests,
+ * since the setImmediate forwards the res.end at the end of the poll phase of libuv in the event loop.
+ * So we can gather multiple requests and then handle all the replies in a different moment,
+ * causing a general improvement of performances, ~+10%.
+ */
+
 const urlUtil = require('url')
 const pump = require('pump')
 const jsonParser = require('body/json')
@@ -11,8 +19,7 @@ function bodyParsed (handle, params, req, res) {
   function parsed (err, body) {
     if (err) {
       res.statusCode = 422
-      res.end()
-      return
+      return setImmediate(wrapResEnd, res)
     }
     handler(handle, params, req, res, body, null)
   }
@@ -25,8 +32,7 @@ function routerHandler (node) {
 
     if (!handle) {
       res.statusCode = 404
-      res.end()
-      return
+      return setImmediate(wrapResEnd, res)
     }
 
     // Body not required
@@ -41,8 +47,7 @@ function routerHandler (node) {
           return jsonParser(req, bodyParsed(handle, params, req, res))
         }
         res.statusCode = 415
-        res.end()
-        return
+        return setImmediate(wrapResEnd, res)
       }
       return handler(handle, params, req, res, null, urlUtil.parse(req.url, true).query)
     }
@@ -53,12 +58,11 @@ function routerHandler (node) {
         return jsonParser(req, bodyParsed(handle, params, req, res))
       }
       res.statusCode = 415
-      res.end()
-      return
+      return setImmediate(wrapResEnd, res)
     }
 
     res.statusCode = 404
-    res.end()
+    setImmediate(wrapResEnd, res)
   }
   return handle
 }
@@ -73,19 +77,21 @@ function build (url, router) {
 function handler (handle, params, req, res, body, query) {
   if (!handle) {
     res.statusCode = 404
-    res.end()
-    return
+    return setImmediate(wrapResEnd, res)
   }
 
   const valid = validateSchema(handle, params, body, query)
   if (valid !== true) {
     res.statusCode = 400
-    res.end(valid)
-    return
+    return setImmediate(wrapResEnd, res, valid)
   }
 
   const request = new Request(params, req, body, query)
   handle.handler(request, new Reply(res, handle))
+}
+
+function wrapResEnd (res, payload) {
+  res.end(payload)
 }
 
 function Reply (res, handle) {
@@ -95,20 +101,18 @@ function Reply (res, handle) {
 
 Reply.prototype.send = function (payload) {
   if (payload instanceof Error) {
-    if (!this.res.statusCode) {
+    if (!this.res.statusCode || this.res.statusCode < 500) {
       this.res.statusCode = 500
     }
-    return this.res.end()
+    return setImmediate(wrapReplyEnd, this)
   }
 
   if (payload && typeof payload.then === 'function') {
-    return payload.then(wrapSend(this)).catch(wrapSend(this))
+    return payload.then(wrapReplySend(this)).catch(wrapReplySend(this))
   }
 
-  if (!payload) {
-    if (!this.res.statusCode) {
-      this.res.statusCode = 204
-    }
+  if (!payload && !this.res.statusCode) {
+    this.res.statusCode = 204
   }
 
   if (payload && payload._readableState) {
@@ -116,7 +120,7 @@ Reply.prototype.send = function (payload) {
       this.res.setHeader('Content-Type', 'application/octet-stream')
     }
     return pump(payload, this.res, err => {
-      if (err) this.res.end()
+      if (err) setImmediate(wrapReplyEnd, this)
     })
   }
 
@@ -127,10 +131,10 @@ Reply.prototype.send = function (payload) {
     if (!this.res.getHeader('Content-Length')) {
       this.res.setHeader('Content-Length', Buffer.byteLength(str))
     }
-    return this.res.end(str)
+    return setImmediate(wrapReplyEnd, this, str)
   }
 
-  this.res.end(payload)
+  setImmediate(wrapReplyEnd, this, payload)
 }
 
 Reply.prototype.header = function (key, value) {
@@ -143,7 +147,11 @@ Reply.prototype.code = function (code) {
   return this
 }
 
-function wrapSend (reply) {
+function wrapReplyEnd (reply, payload) {
+  reply.res.end(payload)
+}
+
+function wrapReplySend (reply, payload) {
   return function send (payload) {
     return reply.send(payload)
   }

--- a/lib/tier-node.js
+++ b/lib/tier-node.js
@@ -11,6 +11,7 @@
 const urlUtil = require('url')
 const pump = require('pump')
 const jsonParser = require('body/json')
+const safeStringify = require('fast-safe-stringify')
 const validation = require('./validation')
 const validateSchema = validation.validate
 const serialize = validation.serialize
@@ -104,7 +105,7 @@ Reply.prototype.send = function (payload) {
     if (!this.res.statusCode || this.res.statusCode < 500) {
       this.res.statusCode = 500
     }
-    return setImmediate(wrapReplyEnd, this)
+    return setImmediate(wrapReplyEnd, this, safeStringify(payload))
   }
 
   if (payload && typeof payload.then === 'function') {
@@ -119,9 +120,7 @@ Reply.prototype.send = function (payload) {
     if (!this.res.getHeader('Content-Type')) {
       this.res.setHeader('Content-Type', 'application/octet-stream')
     }
-    return pump(payload, this.res, err => {
-      if (err) setImmediate(wrapReplyEnd, this)
-    })
+    return pump(payload, this.res, wrapPumpCallback(this))
   }
 
   if (!this.res.getHeader('Content-Type') || this.res.getHeader('Content-Type') === 'application/json') {
@@ -145,6 +144,12 @@ Reply.prototype.header = function (key, value) {
 Reply.prototype.code = function (code) {
   this.res.statusCode = code
   return this
+}
+
+function wrapPumpCallback (reply) {
+  return function pumpCallback (err) {
+    if (err) setImmediate(wrapReplyEnd, reply)
+  }
 }
 
 function wrapReplyEnd (reply, payload) {

--- a/lib/tier-node.js
+++ b/lib/tier-node.js
@@ -92,29 +92,36 @@ function Reply (res, handle) {
   this.handle = handle
 }
 
-Reply.prototype.reply = function (err, statusCode, data) {
-  if (err) {
-    this.res.statusCode = 500
+Reply.prototype.send = function (payload) {
+  if (payload instanceof Error) {
+    if (!this.res.statusCode) {
+      this.res.statusCode = 500
+    }
     this.res.end()
     return
   }
 
-  if (!data) {
-    data = statusCode
-    statusCode = 200
+  if (!payload) {
+    if (!this.res.statusCode) {
+      this.res.statusCode = 204
+    }
   }
 
-  const str = serialize(this.handle, data)
-  this.res.setHeader('Content-Length', Buffer.byteLength(str))
+  const str = serialize(this.handle, payload)
+  if (!this.res.getHeader('Content-Length')) {
+    this.res.setHeader('Content-Length', Buffer.byteLength(str))
+  }
 
   if (!this.res.getHeader('Content-Type')) {
     this.res.setHeader('Content-Type', 'application/json')
   }
+
   if (!this.res.statusCode) {
-    this.res.statusCode = statusCode
+    this.res.statusCode = 200
   }
 
   this.res.end(str)
+  return this
 }
 
 Reply.prototype.header = function (key, value) {
@@ -135,4 +142,4 @@ function Request (params, req, body, query) {
 }
 
 module.exports = build
-module.exports._internals = { bodyParsed, routerHandler, Request, handler }
+module.exports._internals = { bodyParsed, routerHandler, Request, handler, Reply }

--- a/lib/tier-node.js
+++ b/lib/tier-node.js
@@ -104,6 +104,7 @@ function Reply (req, res, handle) {
   this.res = res
   this.handle = handle
   this.req = req
+  this.sent = false
 }
 
 /**
@@ -114,6 +115,10 @@ function Reply (req, res, handle) {
  * causing a general improvement of performances, ~+10%.
  */
 Reply.prototype.send = function (payload) {
+  if (this.sent) {
+    throw new Error('Reply already sent')
+  }
+
   if (payload instanceof Error) {
     if (!this.res.statusCode || this.res.statusCode < 500) {
       this.res.statusCode = 500
@@ -172,6 +177,7 @@ function wrapPumpCallback (reply) {
 }
 
 function wrapReplyEnd (reply, payload) {
+  reply.sent = true
   reply.res.end(payload)
 }
 

--- a/lib/tier-node.js
+++ b/lib/tier-node.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const urlUtil = require('url')
+const pump = require('pump')
 const jsonParser = require('body/json')
 const validation = require('./validation')
 const validateSchema = validation.validate
@@ -97,8 +98,7 @@ Reply.prototype.send = function (payload) {
     if (!this.res.statusCode) {
       this.res.statusCode = 500
     }
-    this.res.end()
-    return
+    return this.res.end()
   }
 
   if (!payload) {
@@ -107,21 +107,26 @@ Reply.prototype.send = function (payload) {
     }
   }
 
-  const str = serialize(this.handle, payload)
-  if (!this.res.getHeader('Content-Length')) {
-    this.res.setHeader('Content-Length', Buffer.byteLength(str))
+  if (payload && payload._readableState) {
+    if (!this.res.getHeader('Content-Type')) {
+      this.res.setHeader('Content-Type', 'application/octet-stream')
+    }
+    return pump(payload, this.res, err => {
+      if (err) this.res.end()
+    })
   }
 
-  if (!this.res.getHeader('Content-Type')) {
+  if (!this.res.getHeader('Content-Type') || this.res.getHeader('Content-Type') === 'application/json') {
     this.res.setHeader('Content-Type', 'application/json')
+
+    const str = serialize(this.handle, payload)
+    if (!this.res.getHeader('Content-Length')) {
+      this.res.setHeader('Content-Length', Buffer.byteLength(str))
+    }
+    return this.res.end(str)
   }
 
-  if (!this.res.statusCode) {
-    this.res.statusCode = 200
-  }
-
-  this.res.end(str)
-  return this
+  this.res.end(payload)
 }
 
 Reply.prototype.header = function (key, value) {
@@ -142,4 +147,4 @@ function Request (params, req, body, query) {
 }
 
 module.exports = build
-module.exports._internals = { bodyParsed, routerHandler, Request, handler, Reply }
+module.exports[Symbol.for('internals')] = { bodyParsed, routerHandler, Request, handler, Reply }

--- a/lib/tier-node.js
+++ b/lib/tier-node.js
@@ -101,6 +101,10 @@ Reply.prototype.send = function (payload) {
     return this.res.end()
   }
 
+  if (payload && typeof payload.then === 'function') {
+    return payload.then(wrapSend(this)).catch(wrapSend(this))
+  }
+
   if (!payload) {
     if (!this.res.statusCode) {
       this.res.statusCode = 204
@@ -137,6 +141,12 @@ Reply.prototype.header = function (key, value) {
 Reply.prototype.code = function (code) {
   this.res.statusCode = code
   return this
+}
+
+function wrapSend (reply) {
+  return function send (payload) {
+    return reply.send(payload)
+  }
 }
 
 function Request (params, req, body, query) {

--- a/lib/tier-node.js
+++ b/lib/tier-node.js
@@ -87,7 +87,11 @@ function handler (handle, params, req, res, body, query) {
   }
 
   const request = new Request(params, req, body, query)
-  handle.handler(request, new Reply(res, handle))
+  const reply = new Reply(req, res, handle)
+  const result = handle.handler(request, reply)
+  if (result && typeof result.then === 'function') {
+    reply.send(result)
+  }
 }
 
 function wrapResEnd (res, payload) {
@@ -95,9 +99,10 @@ function wrapResEnd (res, payload) {
   return
 }
 
-function Reply (res, handle) {
+function Reply (req, res, handle) {
   this.res = res
   this.handle = handle
+  this.req = req
 }
 
 /**
@@ -158,7 +163,10 @@ Reply.prototype.code = function (code) {
 
 function wrapPumpCallback (reply) {
   return function pumpCallback (err) {
-    if (err) setImmediate(wrapReplyEnd, reply)
+    if (err) {
+      reply.req.log.error(err)
+      setImmediate(wrapReplyEnd, reply)
+    }
   }
 }
 

--- a/lib/tier-node.js
+++ b/lib/tier-node.js
@@ -88,7 +88,8 @@ function handler (handle, params, req, res, body, query) {
 
   const request = new Request(params, req, body, query)
   const reply = new Reply(req, res, handle)
-  const result = handle.handler(request, reply)
+  const handler = handle.handler
+  const result = handler(request, reply)
   if (result && typeof result.then === 'function') {
     reply.send(result)
   }

--- a/lib/tier-node.js
+++ b/lib/tier-node.js
@@ -1,13 +1,5 @@
 'use strict'
 
-/**
- * Instead of using directly res.end(), we are using setImmediate(…)
- * This because we have observed that with this technique we are faster at responding to the various requests,
- * since the setImmediate forwards the res.end at the end of the poll phase of libuv in the event loop.
- * So we can gather multiple requests and then handle all the replies in a different moment,
- * causing a general improvement of performances, ~+10%.
- */
-
 const urlUtil = require('url')
 const pump = require('pump')
 const jsonParser = require('body/json')
@@ -20,7 +12,8 @@ function bodyParsed (handle, params, req, res) {
   function parsed (err, body) {
     if (err) {
       res.statusCode = 422
-      return setImmediate(wrapResEnd, res)
+      setImmediate(wrapResEnd, res)
+      return
     }
     handler(handle, params, req, res, body, null)
   }
@@ -33,7 +26,8 @@ function routerHandler (node) {
 
     if (!handle) {
       res.statusCode = 404
-      return setImmediate(wrapResEnd, res)
+      setImmediate(wrapResEnd, res)
+      return
     }
 
     // Body not required
@@ -48,7 +42,8 @@ function routerHandler (node) {
           return jsonParser(req, bodyParsed(handle, params, req, res))
         }
         res.statusCode = 415
-        return setImmediate(wrapResEnd, res)
+        setImmediate(wrapResEnd, res)
+        return
       }
       return handler(handle, params, req, res, null, urlUtil.parse(req.url, true).query)
     }
@@ -59,11 +54,13 @@ function routerHandler (node) {
         return jsonParser(req, bodyParsed(handle, params, req, res))
       }
       res.statusCode = 415
-      return setImmediate(wrapResEnd, res)
+      setImmediate(wrapResEnd, res)
+      return
     }
 
     res.statusCode = 404
     setImmediate(wrapResEnd, res)
+    return
   }
   return handle
 }
@@ -78,13 +75,15 @@ function build (url, router) {
 function handler (handle, params, req, res, body, query) {
   if (!handle) {
     res.statusCode = 404
-    return setImmediate(wrapResEnd, res)
+    setImmediate(wrapResEnd, res)
+    return
   }
 
   const valid = validateSchema(handle, params, body, query)
   if (valid !== true) {
     res.statusCode = 400
-    return setImmediate(wrapResEnd, res, valid)
+    setImmediate(wrapResEnd, res, valid)
+    return
   }
 
   const request = new Request(params, req, body, query)
@@ -93,6 +92,7 @@ function handler (handle, params, req, res, body, query) {
 
 function wrapResEnd (res, payload) {
   res.end(payload)
+  return
 }
 
 function Reply (res, handle) {
@@ -100,12 +100,20 @@ function Reply (res, handle) {
   this.handle = handle
 }
 
+/**
+ * Instead of using directly res.end(), we are using setImmediate(…)
+ * This because we have observed that with this technique we are faster at responding to the various requests,
+ * since the setImmediate forwards the res.end at the end of the poll phase of libuv in the event loop.
+ * So we can gather multiple requests and then handle all the replies in a different moment,
+ * causing a general improvement of performances, ~+10%.
+ */
 Reply.prototype.send = function (payload) {
   if (payload instanceof Error) {
     if (!this.res.statusCode || this.res.statusCode < 500) {
       this.res.statusCode = 500
     }
-    return setImmediate(wrapReplyEnd, this, safeStringify(payload))
+    setImmediate(wrapReplyEnd, this, safeStringify(payload))
+    return
   }
 
   if (payload && typeof payload.then === 'function') {
@@ -130,10 +138,12 @@ Reply.prototype.send = function (payload) {
     if (!this.res.getHeader('Content-Length')) {
       this.res.setHeader('Content-Length', Buffer.byteLength(str))
     }
-    return setImmediate(wrapReplyEnd, this, str)
+    setImmediate(wrapReplyEnd, this, str)
+    return
   }
 
   setImmediate(wrapReplyEnd, this, payload)
+  return
 }
 
 Reply.prototype.header = function (key, value) {

--- a/package.json
+++ b/package.json
@@ -27,17 +27,17 @@
   },
   "homepage": "https://github.com/mcollina/fastify#readme",
   "devDependencies": {
-    "bluebird": "^3.4.6",
+    "bluebird": "^3.4.7",
     "coveralls": "^2.11.15",
     "express": "^4.14.0",
-    "hapi": "^15.2.0",
+    "hapi": "^16.0.2",
     "koa": "^1.2.4",
     "pre-commit": "^1.1.3",
     "request": "^2.79.0",
     "snazzy": "^5.0.0",
     "split2": "^2.1.0",
     "standard": "^8.6.0",
-    "take-five": "^1.3.0",
+    "take-five": "^1.3.1",
     "tap": "^8.0.1"
   },
   "dependencies": {
@@ -48,7 +48,7 @@
     "fast-safe-stringify": "^1.1.3",
     "pathname-match": "^1.2.0",
     "pino-http": "^2.1.0",
-    "pump": "^1.0.1",
+    "pump": "^1.0.2",
     "wayfarer": "^6.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "split2": "^2.1.0",
     "standard": "^8.6.0",
     "take-five": "^1.3.1",
-    "tap": "^8.0.1"
+    "tap": "^8.0.1",
+    "then-sleep": "^1.0.1"
   },
   "dependencies": {
     "ajv": "^4.9.0",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Fast and low overhead web framework, for Node.js",
   "main": "fastify.js",
   "scripts": {
-    "test": "standard | snazzy",
-    "xtest": "standard | snazzy && tap test/*.test.js test/*/*.test.js",
+    "test": "standard | snazzy && tap test/*.test.js test/*/*.test.js",
     "coverage": "tap --cov --coverage-report=html test/*.test.js test/*/*.test.js",
     "coveralls": "tap test/*test.js  test/*/*.test.js --cov --coverage-report=text-lcov | coveralls"
   },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/mcollina/fastify#readme",
   "devDependencies": {
+    "bluebird": "^3.4.6",
     "coveralls": "^2.11.15",
     "express": "^4.14.0",
     "hapi": "^15.2.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Fast and low overhead web framework, for Node.js",
   "main": "fastify.js",
   "scripts": {
-    "test": "standard | snazzy && tap test/*.test.js test/*/*.test.js",
+    "test": "standard | snazzy",
+    "xtest": "standard | snazzy && tap test/*.test.js test/*/*.test.js",
     "coverage": "tap --cov --coverage-report=html test/*.test.js test/*/*.test.js",
     "coveralls": "tap test/*test.js  test/*/*.test.js --cov --coverage-report=text-lcov | coveralls"
   },

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "fast-safe-stringify": "^1.1.3",
     "pathname-match": "^1.2.0",
     "pino-http": "^2.1.0",
+    "pump": "^1.0.1",
     "wayfarer": "^6.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "homepage": "https://github.com/mcollina/fastify#readme",
   "devDependencies": {
-    "bluebird": "^3.4.6",
     "coveralls": "^2.11.15",
     "express": "^4.14.0",
     "hapi": "^15.2.0",

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -17,7 +17,7 @@ const schema = {
 }
 
 fastify.get('/', schema, function (req, reply) {
-  reply(null, 200, { hello: 'world' })
+  reply.send({ hello: 'world' })
 })
 
 fastify.listen(3000, err => {

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -21,8 +21,20 @@ function asyncTest (t) {
   test('shorthand - async await get', t => {
     t.plan(1)
     try {
-      fastify.get('/', schema, async function (req, reply) {
-        await sleep(500)
+      fastify.get('/', schema, async function awaitMyFunc (req, reply) {
+        await sleep(200)
+        return { hello: 'world' }
+      })
+      t.pass()
+    } catch (e) {
+      t.fail()
+    }
+  })
+
+  test('shorthand - async await get', t => {
+    t.plan(1)
+    try {
+      fastify.get('/no-await', schema, async function (req, reply) {
         return { hello: 'world' }
       })
       t.pass()
@@ -47,7 +59,24 @@ function asyncTest (t) {
         t.deepEqual(JSON.parse(body), { hello: 'world' })
       })
     })
+
+    test('shorthand - request async test', t => {
+      t.plan(4)
+      request({
+        method: 'GET',
+        uri: 'http://localhost:' + fastify.server.address().port + '/no-await'
+      }, (err, response, body) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 200)
+        t.strictEqual(response.headers['content-length'], '' + body.length)
+        t.deepEqual(JSON.parse(body), { hello: 'world' })
+      })
+    })
   })
 }
 
 module.exports = asyncTest
+
+if (require.main === module) {
+  asyncTest(require('tap'))
+}

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const request = require('request')
+const fastify = require('..')()
+const sleep = require('then-sleep')
+
+const schema = {
+  out: {
+    type: 'object',
+    properties: {
+      hello: {
+        type: 'string'
+      }
+    }
+  }
+}
+
+function asyncTest (t) {
+  const test = t.test
+
+  test('shorthand - async await get', t => {
+    t.plan(1)
+    try {
+      fastify.get('/', schema, async function (req, reply) {
+        await sleep(500)
+        return { hello: 'world' }
+      })
+      t.pass()
+    } catch (e) {
+      t.fail()
+    }
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    fastify.server.unref()
+
+    test('shorthand - request async await test', t => {
+      t.plan(4)
+      request({
+        method: 'GET',
+        uri: 'http://localhost:' + fastify.server.address().port
+      }, (err, response, body) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 200)
+        t.strictEqual(response.headers['content-length'], '' + body.length)
+        t.deepEqual(JSON.parse(body), { hello: 'world' })
+      })
+    })
+  })
+}
+
+module.exports = asyncTest

--- a/test/async-await.test.js
+++ b/test/async-await.test.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const t = require('tap')
+
+if (Number(process.versions.node[0]) >= 7) {
+  const v8 = require('v8')
+  v8.setFlagsFromString('--harmony_async_await')
+  require('./async-await.js')(t)
+} else {
+  t.pass('Skip because Node version < 7')
+}

--- a/test/async-await.test.js
+++ b/test/async-await.test.js
@@ -1,11 +1,14 @@
 'use strict'
 
-const t = require('tap')
+const path = require('path')
+const childProcess = require('child_process')
+const tap = require('tap')
 
 if (Number(process.versions.node[0]) >= 7) {
-  const v8 = require('v8')
-  v8.setFlagsFromString('--harmony_async_await')
-  require('./async-await.js')(t)
+  childProcess.fork(path.join(__dirname, 'async-await'), [], {
+    execArgv: ['--harmony-async-await']
+  })
 } else {
-  t.pass('Skip because Node version < 7')
+  tap.pass('Skip because Node version < 7')
+  tap.end()
 }

--- a/test/delete.test.js
+++ b/test/delete.test.js
@@ -45,7 +45,7 @@ test('shorthand - delete', t => {
   t.plan(1)
   try {
     fastify.delete('/', schema, function (req, reply) {
-      reply(null, 200, { hello: 'world' })
+      reply.code(200).send({ hello: 'world' })
     })
     t.pass()
   } catch (e) {
@@ -57,7 +57,7 @@ test('shorthand - delete params', t => {
   t.plan(1)
   try {
     fastify.delete('/params/:foo/:test', paramsSchema, function (req, reply) {
-      reply(null, 200, req.params)
+      reply.code(200).send(req.params)
     })
     t.pass()
   } catch (e) {
@@ -69,7 +69,7 @@ test('shorthand - delete, querystring schema', t => {
   t.plan(1)
   try {
     fastify.delete('/query', querySchema, function (req, reply) {
-      reply(null, 200, req.query)
+      reply.send(req.query)
     })
     t.pass()
   } catch (e) {
@@ -81,7 +81,7 @@ test('missing schema - delete', t => {
   t.plan(1)
   try {
     fastify.delete('/missing', function (req, reply) {
-      reply(null, 200, { hello: 'world' })
+      reply.code(200).send({ hello: 'world' })
     })
     t.pass()
   } catch (e) {

--- a/test/get.test.js
+++ b/test/get.test.js
@@ -45,7 +45,7 @@ test('shorthand - get', t => {
   t.plan(1)
   try {
     fastify.get('/', schema, function (req, reply) {
-      reply(null, 200, { hello: 'world' })
+      reply.code(200).send({ hello: 'world' })
     })
     t.pass()
   } catch (e) {
@@ -57,7 +57,7 @@ test('shorthand - get params', t => {
   t.plan(1)
   try {
     fastify.get('/params/:foo/:test', paramsSchema, function (req, reply) {
-      reply(null, 200, req.params)
+      reply.code(200).send(req.params)
     })
     t.pass()
   } catch (e) {
@@ -69,7 +69,7 @@ test('shorthand - get, querystring schema', t => {
   t.plan(1)
   try {
     fastify.get('/query', querySchema, function (req, reply) {
-      reply(null, 200, req.query)
+      reply.code(200).send(req.query)
     })
     t.pass()
   } catch (e) {
@@ -81,7 +81,7 @@ test('missing schema - get', t => {
   t.plan(1)
   try {
     fastify.get('/missing', function (req, reply) {
-      reply(null, 200, { hello: 'world' })
+      reply.code(200).send({ hello: 'world' })
     })
     t.pass()
   } catch (e) {

--- a/test/head.test.js
+++ b/test/head.test.js
@@ -7,12 +7,7 @@ const fastify = require('..')()
 
 const schema = {
   out: {
-    type: 'object',
-    properties: {
-      hello: {
-        type: 'string'
-      }
-    }
+    type: 'null'
   }
 }
 
@@ -45,7 +40,7 @@ test('shorthand - head', t => {
   t.plan(1)
   try {
     fastify.head('/', schema, function (req, reply) {
-      reply(null, 200)
+      reply.code(200).send(null)
     })
     t.pass()
   } catch (e) {
@@ -57,7 +52,7 @@ test('shorthand - head params', t => {
   t.plan(1)
   try {
     fastify.head('/params/:foo/:test', paramsSchema, function (req, reply) {
-      reply(null, 200)
+      reply.send(null)
     })
     t.pass()
   } catch (e) {
@@ -69,7 +64,7 @@ test('shorthand - head, querystring schema', t => {
   t.plan(1)
   try {
     fastify.head('/query', querySchema, function (req, reply) {
-      reply(null, 200)
+      reply.code(200).send(null)
     })
     t.pass()
   } catch (e) {
@@ -81,7 +76,7 @@ test('missing schema - head', t => {
   t.plan(1)
   try {
     fastify.head('/missing', function (req, reply) {
-      reply(null, 200)
+      reply.code(200).send(null)
     })
     t.pass()
   } catch (e) {

--- a/test/helper.js
+++ b/test/helper.js
@@ -23,7 +23,7 @@ module.exports.payloadMethod = function (method, t) {
     t.plan(1)
     try {
       fastify[loMethod]('/', schema, function (req, reply) {
-        reply(null, 200, req.body)
+        reply.code(200).send(req.body)
       })
       t.pass()
     } catch (e) {
@@ -35,7 +35,7 @@ module.exports.payloadMethod = function (method, t) {
     t.plan(1)
     try {
       fastify[loMethod]('/missing', function (req, reply) {
-        reply(null, 200, req.body)
+        reply.code(200).send(req.body)
       })
       t.pass()
     } catch (e) {
@@ -86,7 +86,7 @@ module.exports.payloadMethod = function (method, t) {
       t.plan(2)
       request({
         method: upMethod,
-        uri: 'http://localhost:' + fastify.server.address().port,
+        uri: 'http://localhost:' + fastify.server.address().port + '/missing',
         body: 'hello world',
         timeout: 200
       }, (err, response, body) => {
@@ -98,6 +98,24 @@ module.exports.payloadMethod = function (method, t) {
         }
       })
     })
+
+    if (loMethod === 'options') {
+      test(`OPTIONS returns 415 - should return 415 if Content-Type is not json`, t => {
+        t.plan(2)
+        request({
+          method: upMethod,
+          uri: 'http://localhost:' + fastify.server.address().port + '/missing',
+          body: 'hello world',
+          headers: {
+            'Content-Type': 'text/plain'
+          },
+          timeout: 200
+        }, (err, response, body) => {
+          t.error(err)
+          t.strictEqual(response.statusCode, 415)
+        })
+      })
+    }
 
     test(`${upMethod} returns 422 - Unprocessable Entity`, t => {
       t.plan(2)

--- a/test/input-validation.js
+++ b/test/input-validation.js
@@ -23,7 +23,7 @@ module.exports.payloadMethod = function (method, t) {
     t.plan(1)
     try {
       fastify[loMethod]('/', schema, function (req, reply) {
-        reply(null, 200, req.body)
+        reply.send(req.body)
       })
       t.pass()
     } catch (e) {

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -59,6 +59,18 @@ test('Reply can set code and header of a response', t => {
   }
 })
 
+test('Reply.send should return undefined', t => {
+  t.plan(2)
+  try {
+    fastify.get('/undefined', function (req, reply) {
+      t.strictEqual(reply.send('hello world!'), undefined)
+    })
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+})
+
 fastify.listen(0, err => {
   t.error(err)
   fastify.server.unref()
@@ -86,5 +98,12 @@ fastify.listen(0, err => {
       t.strictEqual(response.statusCode, 200)
       t.deepEqual(JSON.parse(body), 'hello world!')
     })
+  })
+
+  request({
+    method: 'GET',
+    uri: 'http://localhost:' + fastify.server.address().port + '/undefined'
+  }, (err, response, body) => {
+    t.error(err)
   })
 })

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -13,22 +13,25 @@ test('Reply should be an object', t => {
 })
 
 test('Once called, Reply should return an object with methods', t => {
-  t.plan(6)
+  t.plan(7)
+  const request = { req: 'req' }
   const response = { res: 'res' }
   function handle () {}
-  const reply = new internals.Reply(response, handle)
+  const reply = new internals.Reply(request, response, handle)
   t.is(typeof reply, 'object')
   t.is(typeof reply.send, 'function')
   t.is(typeof reply.code, 'function')
   t.is(typeof reply.header, 'function')
+  t.strictEqual(reply.req, request)
   t.strictEqual(reply.res, response)
   t.strictEqual(reply.handle, handle)
 })
 
 test('reply.header and reply.code should return an instance of Reply', t => {
   t.plan(2)
+  const request = {}
   const response = { setHeader: () => {} }
-  const reply = new internals.Reply(response, null)
+  const reply = new internals.Reply(request, response, null)
   t.type(reply.code(1), internals.Reply)
   t.type(reply.header('hello', 'world'), internals.Reply)
 })

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -5,7 +5,7 @@ const test = t.test
 const request = require('request')
 const fastify = require('../..')()
 
-const internals = require('../../lib/tier-node')._internals
+const internals = require('../../lib/tier-node')[Symbol.for('internals')]
 
 test('Reply should be an object', t => {
   t.plan(1)
@@ -23,6 +23,14 @@ test('Once called, Reply should return an object with methods', t => {
   t.is(typeof reply.header, 'function')
   t.strictEqual(reply.res, response)
   t.strictEqual(reply.handle, handle)
+})
+
+test('reply.header and reply.code should return an instance of Reply', t => {
+  t.plan(2)
+  const response = { setHeader: () => {} }
+  const reply = new internals.Reply(response, null)
+  t.type(reply.code(1), internals.Reply)
+  t.type(reply.header('hello', 'world'), internals.Reply)
 })
 
 test('Reply can set code and header of a response', t => {
@@ -64,7 +72,7 @@ fastify.listen(0, err => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)
       t.strictEqual(response.headers['content-type'], 'text/plain')
-      t.deepEqual(JSON.parse(body), 'hello world!')
+      t.deepEqual(body, 'hello world!')
     })
   })
 

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -1,0 +1,82 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const request = require('request')
+const fastify = require('../..')()
+
+const internals = require('../../lib/tier-node')._internals
+
+test('Reply should be an object', t => {
+  t.plan(1)
+  t.is(typeof internals.Reply, 'function')
+})
+
+test('Once called, Reply should return an object with methods', t => {
+  t.plan(6)
+  const response = { res: 'res' }
+  function handle () {}
+  const reply = new internals.Reply(response, handle)
+  t.is(typeof reply, 'object')
+  t.is(typeof reply.send, 'function')
+  t.is(typeof reply.code, 'function')
+  t.is(typeof reply.header, 'function')
+  t.strictEqual(reply.res, response)
+  t.strictEqual(reply.handle, handle)
+})
+
+test('Reply can set code and header of a response', t => {
+  t.plan(1)
+  try {
+    fastify.get('/', function (req, reply) {
+      reply.code(200)
+      reply.header('Content-Type', 'text/plain')
+      reply.send('hello world!')
+    })
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+})
+
+test('Reply can set code and header of a response', t => {
+  t.plan(1)
+  try {
+    fastify.get('/auto-status-code', function (req, reply) {
+      reply.send('hello world!')
+    })
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+})
+
+fastify.listen(0, err => {
+  t.error(err)
+  fastify.server.unref()
+
+  test('status code and content-type should be correct', t => {
+    t.plan(4)
+    request({
+      method: 'GET',
+      uri: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-type'], 'text/plain')
+      t.deepEqual(JSON.parse(body), 'hello world!')
+    })
+  })
+
+  test('auto status code shoud be 200', t => {
+    t.plan(3)
+    request({
+      method: 'GET',
+      uri: 'http://localhost:' + fastify.server.address().port + '/auto-status-code'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.deepEqual(JSON.parse(body), 'hello world!')
+    })
+  })
+})

--- a/test/internals/tier-node.test.js
+++ b/test/internals/tier-node.test.js
@@ -58,13 +58,19 @@ test('handler function - reply', t => {
   t.plan(3)
   const res = {}
   res.end = () => {
-    t.equal(res.statusCode, 200)
+    t.equal(res.statusCode, 204)
     t.pass()
+  }
+  res.getHeader = (key) => {
+    return false
+  }
+  res.setHeader = (key, value) => {
+    return
   }
   const handle = {
     handler: (req, reply) => {
-      t.is(typeof reply, 'function')
-      reply(null, null)
+      t.is(typeof reply, 'object')
+      reply.send(null)
     }
   }
   buildSchema(handle)
@@ -112,7 +118,7 @@ test('routerHandler function - call handle', t => {
   const handleNode = {
     handler: (req, reply) => {
       t.equal(req.req.url, 'http://example.com')
-      reply(null, null)
+      reply.send(null)
     }
   }
   buildSchema(handleNode)
@@ -122,8 +128,14 @@ test('routerHandler function - call handle', t => {
   })
   const res = {}
   res.end = () => {
-    t.equal(res.statusCode, 200)
+    t.equal(res.statusCode, 204)
     t.pass()
+  }
+  res.getHeader = (key) => {
+    return false
+  }
+  res.setHeader = (key, value) => {
+    return
   }
   const req = {
     method: 'GET',
@@ -137,7 +149,7 @@ test('reply function - error 500', t => {
   const handleNode = {
     handler: (req, reply) => {
       t.equal(req.req.url, 'http://example.com')
-      reply(new Error('error'), null)
+      reply.send(new Error('error'))
     }
   }
   buildSchema(handleNode)

--- a/test/internals/tier-node.test.js
+++ b/test/internals/tier-node.test.js
@@ -3,7 +3,7 @@
 const t = require('tap')
 const test = t.test
 
-const internals = require('../../lib/tier-node')._internals
+const internals = require('../../lib/tier-node')[Symbol.for('internals')]
 const buildSchema = require('../../lib/validation').build
 
 test('Request object', t => {

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -22,7 +22,7 @@ try {
 
 fastify.get('/', function (req, reply) {
   t.ok(req.req.log)
-  reply(null, 200, { hello: 'world' })
+  reply.send(null, 200, { hello: 'world' })
 })
 
 test('test log stream', t => {

--- a/test/promises.test.js
+++ b/test/promises.test.js
@@ -1,0 +1,131 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const request = require('request')
+const Bluebird = require('bluebird')
+const fastify = require('..')()
+
+const schema = {
+  out: {
+    type: 'object',
+    properties: {
+      hello: {
+        type: 'string'
+      }
+    }
+  }
+}
+
+test('shorthand - promise es6 get', t => {
+  t.plan(1)
+  try {
+    fastify.get('/', schema, function (req, reply) {
+      const promise = new Promise((resolve, reject) => {
+        resolve({ hello: 'world' })
+      })
+      reply.header('content-type', 'application/json').code(200).send(promise)
+    })
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+})
+
+test('shorthand - promise es6 get error', t => {
+  t.plan(1)
+  try {
+    fastify.get('/error', schema, function (req, reply) {
+      const promise = new Promise((resolve, reject) => {
+        reject(new Error('some error'))
+      })
+      reply.send(promise)
+    })
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+})
+
+test('shorthand - promise bluebird get', t => {
+  t.plan(1)
+  try {
+    fastify.get('/bluebird', schema, function (req, reply) {
+      const promise = new Bluebird((resolve, reject) => {
+        resolve({ hello: 'world' })
+      })
+      reply.header('content-type', 'application/json').code(200).send(promise)
+    })
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+})
+
+test('shorthand - promise bluebird get error', t => {
+  t.plan(1)
+  try {
+    fastify.get('/bluebird-error', schema, function (req, reply) {
+      const promise = new Bluebird((resolve, reject) => {
+        reject(new Error('some error'))
+      })
+      reply.send(promise)
+    })
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+})
+
+fastify.listen(0, err => {
+  t.error(err)
+  fastify.server.unref()
+
+  test('shorthand - request promise es6 get', t => {
+    t.plan(4)
+    request({
+      method: 'GET',
+      uri: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.deepEqual(JSON.parse(body), { hello: 'world' })
+    })
+  })
+
+  test('shorthand - request promise es6 get error', t => {
+    t.plan(2)
+    request({
+      method: 'GET',
+      uri: 'http://localhost:' + fastify.server.address().port + '/error'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 500)
+    })
+  })
+
+  test('shorthand - request promise bluebird get', t => {
+    t.plan(4)
+    request({
+      method: 'GET',
+      uri: 'http://localhost:' + fastify.server.address().port + '/bluebird'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.deepEqual(JSON.parse(body), { hello: 'world' })
+    })
+  })
+
+  test('shorthand - request promise bluebird get error', t => {
+    t.plan(2)
+    request({
+      method: 'GET',
+      uri: 'http://localhost:' + fastify.server.address().port + '/bluebird-error'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 500)
+    })
+  })
+})

--- a/test/promises.test.js
+++ b/test/promises.test.js
@@ -32,6 +32,21 @@ test('shorthand - promise es6 get', t => {
   }
 })
 
+test('shorthand - return promise es6 get', t => {
+  t.plan(1)
+  try {
+    fastify.get('/return', schema, function (req, reply) {
+      const promise = new Promise((resolve, reject) => {
+        resolve({ hello: 'world' })
+      })
+      return promise
+    })
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+})
+
 test('shorthand - promise es6 get error', t => {
   t.plan(1)
   try {
@@ -86,6 +101,19 @@ fastify.listen(0, err => {
     request({
       method: 'GET',
       uri: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.deepEqual(JSON.parse(body), { hello: 'world' })
+    })
+  })
+
+  test('shorthand - request return promise es6 get', t => {
+    t.plan(4)
+    request({
+      method: 'GET',
+      uri: 'http://localhost:' + fastify.server.address().port + '/return'
     }, (err, response, body) => {
       t.error(err)
       t.strictEqual(response.statusCode, 200)

--- a/test/promises.test.js
+++ b/test/promises.test.js
@@ -156,4 +156,25 @@ fastify.listen(0, err => {
       t.strictEqual(response.statusCode, 500)
     })
   })
+
+  test('request promise double send', t => {
+    t.plan(4)
+    fastify.get('/kaboom', function (req, reply) {
+      setTimeout(function () {
+        t.throws(function () {
+          reply.send(Promise.resolve({ hello: 'world' }))
+        }, 'double send throws')
+      }, 20)
+      return Promise.resolve({ hello: '42' })
+    })
+
+    request({
+      method: 'GET',
+      uri: 'http://localhost:' + fastify.server.address().port + '/kaboom'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.deepEqual(JSON.parse(body), { hello: '42' })
+    })
+  })
 })

--- a/test/register.test.js
+++ b/test/register.test.js
@@ -14,7 +14,7 @@ test('fastify.register', t => {
       t.is(typeof done, 'function')
 
       instance.get('/first', function (req, reply) {
-        reply(null, 200, { hello: 'world' })
+        reply.send({ hello: 'world' })
       })
       done()
     })
@@ -24,7 +24,7 @@ test('fastify.register', t => {
       t.is(typeof done, 'function')
 
       instance.get('/second', function (req, reply) {
-        reply(null, 200, { hello: 'world' })
+        reply.send({ hello: 'world' })
       })
       done()
     })
@@ -44,7 +44,7 @@ test('fastify.register array', t => {
     t.is(typeof done, 'function')
 
     instance.get('/third', function (req, reply) {
-      reply(null, 200, { hello: 'world' })
+      reply.send({ hello: 'world' })
     })
     done()
   }
@@ -55,7 +55,7 @@ test('fastify.register array', t => {
     t.is(typeof done, 'function')
 
     instance.get('/fourth', function (req, reply) {
-      reply(null, 200, { hello: 'world' })
+      reply.send({ hello: 'world' })
     })
     done()
   }

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -22,7 +22,7 @@ test('route - get', t => {
         }
       },
       handler: function (req, reply) {
-        reply(null, 200, { hello: 'world' })
+        reply.send({ hello: 'world' })
       }
     })
     t.pass()
@@ -38,7 +38,7 @@ test('missing schema - route', t => {
       method: 'GET',
       url: '/missing',
       handler: function (req, reply) {
-        reply(null, 200, { hello: 'world' })
+        reply.send({ hello: 'world' })
       }
     })
     t.pass()

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -1,0 +1,68 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const request = require('request')
+const fs = require('fs')
+const fastify = require('..')()
+
+test('should respond with a stream', t => {
+  t.plan(1)
+  try {
+    fastify.get('/', function (req, reply) {
+      const stream = fs.createReadStream(process.cwd() + '/test/stream.test.js', 'utf8')
+      reply.code(200).send(stream)
+    })
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+})
+
+test('should respond with a stream', t => {
+  t.plan(1)
+  try {
+    fastify.get('/error', function (req, reply) {
+      const stream = fs.createReadStream('not-existing-file', 'utf8')
+      reply.code(200).send(stream)
+    })
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+})
+
+fastify.listen(0, err => {
+  t.error(err)
+  fastify.server.unref()
+
+  test('should get a stream response', t => {
+    t.plan(3)
+    request(`http://localhost:${fastify.server.address().port}`)
+      .on('response', response => {
+        t.strictEqual(response.headers['content-type'], 'application/octet-stream')
+        t.strictEqual(response.statusCode, 200)
+      })
+      .on('error', err => {
+        t.error(err)
+      })
+      .on('end', () => {
+        t.pass('Correctly close the stream')
+      })
+  })
+
+  test('should get an errored stream response', t => {
+    t.plan(2)
+    request(`http://localhost:${fastify.server.address().port}/error`)
+      .on('response', response => {
+        t.fail()
+      })
+      .on('error', err => {
+        t.type(err, Error)
+        t.pass('Correctly close the stream')
+      })
+      .on('end', () => {
+        t.fail()
+      })
+  })
+})

--- a/test/throw.test.js
+++ b/test/throw.test.js
@@ -3,6 +3,29 @@
 const test = require('tap').test
 const fastify = require('..')()
 
+test('Fastify should throw on wrong options', t => {
+  t.plan(2)
+  try {
+    const f = require('..')('lol') // eslint-disable-line
+    t.fail()
+  } catch (e) {
+    t.is(e.message, 'Options must be an object')
+    t.pass()
+  }
+})
+
+test('Fastify should throw on multiple assignment to the same route', t => {
+  t.plan(2)
+  try {
+    fastify.get('/', () => {})
+    fastify.get('/', () => {})
+    t.fail()
+  } catch (e) {
+    t.is(e.message, 'GET already set for /')
+    t.pass()
+  }
+})
+
 test('Should throw on unsupported method', t => {
   t.plan(1)
   try {


### PR DESCRIPTION
At the moment in master we can serve around 17k req / sec, with this change we can serve around 19.5k req / sec.
Is a ~15% improvement, that's good!

But this perf improvement implies an awful API, `reply.reply`.
Example:
```js
fastify
   .get('/', schema, function (req, reply) {
     reply.header('Content-Type', 'application-json').code(200)
     reply.reply(null, {hello: 'world'})
   })
```
@mcollina @davidmarkclements do you know any ninja trick to get this perf but have a nice looking API?

ps for the moment I disabled all the test, since all of them will fail.
__________

**TODO**:
Stream:
- [x] Test
- [x] Docs
- [x] What to do if pump fails

Reply:
- [x] Promises support
- [x] Test
- [x] Docs
- [x] Async/Await support
