### PR TITLE
reply as func

### DIFF
--- a/examples/example.js
+++ b/examples/example.js
@@ -16,19 +16,19 @@ const schema = {
 fastify
   .get('/', schema, function (req, reply) {
     reply.header('Content-Type', 'text/plain').code(200)
-    reply.send({ hello: 'world' })
+    reply({ hello: 'world' })
   })
   .post('/', schema, function (req, reply) {
-    reply.send(null, { hello: 'world' })
+    reply(null, { hello: 'world' })
   })
   .head('/', {}, function (req, reply) {
-    reply.send(null)
+    reply(null)
   })
   .delete('/', schema, function (req, reply) {
-    reply.send(null, { hello: 'world' })
+    reply(null, { hello: 'world' })
   })
   .patch('/', schema, function (req, reply) {
-    reply.send(null, { hello: 'world' })
+    reply(null, { hello: 'world' })
   })
 
 fastify.listen(3000, err => {

--- a/lib/tier-node.js
+++ b/lib/tier-node.js
@@ -84,54 +84,53 @@ function handler (handle, params, req, res, body, query) {
   }
 
   const request = new Request(params, req, body, query)
-  handle.handler(request, new Reply(res, handle))
+  reply.res = res
+  reply.handle = handle
+  handle.handler(request, reply)
 }
 
-function Reply (res, handle) {
-  this.res = res
-  this.handle = handle
-}
-
-Reply.prototype.send = function (payload) {
+function reply (payload) {
   if (payload instanceof Error) {
-    if (!this.res.statusCode) {
-      this.res.statusCode = 500
+    if (!reply.res.statusCode) {
+      reply.res.statusCode = 500
     }
-    this.res.end()
-    return
+    reply.res.end()
+    return reply
   }
 
   if (!payload) {
-    if (!this.res.statusCode) {
-      this.res.statusCode = 204
+    if (!reply.res.statusCode) {
+      reply.res.statusCode = 204
     }
   }
 
-  const str = serialize(this.handle, payload)
-  if (!this.res.getHeader('Content-Length')) {
-    this.res.setHeader('Content-Length', Buffer.byteLength(str))
+  const str = serialize(reply.handle, payload)
+  if (!reply.res.getHeader('Content-Length')) {
+    reply.res.setHeader('Content-Length', Buffer.byteLength(str))
   }
 
-  if (!this.res.getHeader('Content-Type')) {
-    this.res.setHeader('Content-Type', 'application/json')
+  if (!reply.res.getHeader('Content-Type')) {
+    reply.res.setHeader('Content-Type', 'application/json')
   }
 
-  if (!this.res.statusCode) {
-    this.res.statusCode = 200
+  if (!reply.res.statusCode) {
+    reply.res.statusCode = 200
   }
 
-  this.res.end(str)
-  return this
+  reply.res.end(str)
+  return reply
 }
 
-Reply.prototype.header = function (key, value) {
-  this.res.setHeader(key, value)
-  return this
+reply.send = reply
+
+reply.header = function (key, value) {
+  reply.res.setHeader(key, value)
+  return reply
 }
 
-Reply.prototype.code = function (code) {
-  this.res.statusCode = code
-  return this
+reply.code = function (code) {
+  reply.res.statusCode = code
+  return reply
 }
 
 function Request (params, req, body, query) {
@@ -142,4 +141,4 @@ function Request (params, req, body, query) {
 }
 
 module.exports = build
-module.exports._internals = { bodyParsed, routerHandler, Request, handler, Reply }
+module.exports._internals = { bodyParsed, routerHandler, Request, handler, reply }

--- a/test/internals/reply.test.js
+++ b/test/internals/reply.test.js
@@ -7,17 +7,19 @@ const fastify = require('../..')()
 
 const internals = require('../../lib/tier-node')._internals
 
-test('Reply should be an object', t => {
+test('Reply should be a function', t => {
   t.plan(1)
-  t.is(typeof internals.Reply, 'function')
+  t.is(typeof internals.reply, 'function')
 })
 
-test('Once called, Reply should return an object with methods', t => {
+test('reply is a function with methods', t => {
   t.plan(6)
   const response = { res: 'res' }
   function handle () {}
-  const reply = new internals.Reply(response, handle)
-  t.is(typeof reply, 'object')
+  const reply = internals.reply
+  reply.res = response
+  reply.handle = handle
+  t.is(typeof reply, 'function')
   t.is(typeof reply.send, 'function')
   t.is(typeof reply.code, 'function')
   t.is(typeof reply.header, 'function')

--- a/test/internals/tier-node.test.js
+++ b/test/internals/tier-node.test.js
@@ -69,7 +69,7 @@ test('handler function - reply', t => {
   }
   const handle = {
     handler: (req, reply) => {
-      t.is(typeof reply, 'object')
+      t.is(typeof reply, 'function')
       reply.send(null)
     }
   }


### PR DESCRIPTION
adds to #27 

allows reply to be a function without degrading performance

#27 bench: 
```
Stat         Avg      Stdev     Max
Latency (ms) 0.13     0.36      14
Req/Sec      14002.55 782.28    14911
Bytes/Sec    2 MB     122.46 kB 2.23 MB
```

This PR bench: 

```
Stat         Avg     Stdev     Max
Latency (ms) 0.13    0.36      14
Req/Sec      14344.8 656.02    14999
Bytes/Sec    2.06 MB 109.47 kB 2.23 MB
```

This one shows more, but it varys enough that we can call them equivalent

Propose that this PR is closed and merged into #27 
